### PR TITLE
Fix : 각 이미지/상세정보 레이어를 translate-z 값을 주어 분리

### DIFF
--- a/src/components/Ticket/ImageWithDetail.tsx
+++ b/src/components/Ticket/ImageWithDetail.tsx
@@ -38,6 +38,7 @@ export default function ImageWithDetail(
           style={{
             aspectRatio: gacha.image.ratio,
             width: "100%",
+            translate: "0 0 10px",
           }}
         >
           <img
@@ -59,6 +60,7 @@ export default function ImageWithDetail(
         <div
           style={{
             rotate: "y 180deg",
+            translate: "0 0 -10px",
             backfaceVisibility: "hidden",
           }}
           className="absolute top-0 h-full w-full overflow-y-scroll rounded-md bg-black/60 p-8 text-xl text-white"


### PR DESCRIPTION
모바일에서는 여전히 회전 시에 사진이 깜빡거림이 발생하여
각 이미지/상세정보 레이어를 translate-z 값을 주어 분리함